### PR TITLE
Changed Lambda Node.js runtime from nodejs8.10 to nodejs10.x. 

### DIFF
--- a/S3BucketVersioning/CloudformationTemplate.json
+++ b/S3BucketVersioning/CloudformationTemplate.json
@@ -114,7 +114,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 60
             },
             "Type": "AWS::Lambda::Function"


### PR DESCRIPTION
Lambda no longer supports nodejs8.10 runtime. Updated and tested.

*Issue #, if available:*

*Description of changes:*
Changed the Node.js runtime for the Lambda included in the CloudFormation template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
