### PR TITLE
Updated lambda nodejs runtime, region, dryRun boolean

### DIFF
--- a/LowUtilizationEC2Instances/TAStopLowUtilizationEC2Instances.template
+++ b/LowUtilizationEC2Instances/TAStopLowUtilizationEC2Instances.template
@@ -67,8 +67,8 @@
                                 "// define configuration",
                                 "const tagKey ='environment';",
                                 "const tagValue ='dev';",
-								"const dryRun ='true'; //set to false during testing ",
-                                "const regionSpecification = 'eu-west-1'; //Specify a region to restrict the EC2 Stop Instances action to. Use 'all' for all regions",
+				"const dryRun =true; //set to true during testing ",
+                                "const regionSpecification = 'us-east-1'; //Specify a region to restrict the EC2 Stop Instances action to. Use 'all' for all regions",
                                 "",
                                 "//main function which gets Trusted Advisor data from Cloudwatch event",
                                 "exports.handler = (event, context, callback) => {",
@@ -133,7 +133,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": 60
             },
             "Type": "AWS::Lambda::Function"


### PR DESCRIPTION
Updated nodejs runtime to 10.x (current nodejs8.10 is no longer supported).
Updated dryRun to a boolean. The variable was in quotes and was
failing as it was a string and logic for dryrun is expecting boolean.
Updated regionSpecification to us-east-1 from eu-west-1. Readme says
that the CloudFormation deploys to us-east-1 so thought this best
for consistency.

Tested deployment of cloudformation stack and stopping of EC2 instances that were flagged by TA.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
