### PR TITLE
Adjust runtime to python3.9 in ExposedAccessKeys's Lambdas

### DIFF
--- a/ExposedAccessKeys/cloudformation/exposed_access_keys.serverless.yaml
+++ b/ExposedAccessKeys/cloudformation/exposed_access_keys.serverless.yaml
@@ -102,7 +102,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: delete_access_key_pair.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.9
       CodeUri: ../lambda_functions/
       Role: !GetAtt LambdaDeleteAccessKeyPairRole.Arn
  
@@ -110,7 +110,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: lookup_cloudtrail_events.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.9
       CodeUri: ../lambda_functions/
       Role: !GetAtt LambdaLookupCloudTrailEventsRole.Arn
  
@@ -118,7 +118,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: notify_security.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.9
       CodeUri: ../lambda_functions/
       Role: !GetAtt LambdaSnsPublishRole.Arn
       Environment:


### PR DESCRIPTION
python3.6 is in EoL

*Issue #26*

*Description of changes: Switching to modern and supported python runtime as python3.6 has reached End of Life last year*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
