### PR TITLE
IAM Password Policy

### DIFF
--- a/IAMPasswordPolicy/README.md
+++ b/IAMPasswordPolicy/README.md
@@ -1,0 +1,54 @@
+## IAM Password Policy
+
+### Trusted Advisor Check Description
+
+
+Checks the password policy for your account and warns when a password policy is not enabled, or if password content requirements have not been enabled.
+
+Password content requirements increase the overall security of your AWS environment by enforcing the creation of strong user passwords. When you create or change a password policy, the change is enforced immediately for new users but does not require existing users to change their passwords.
+
+### Alert Criteria
+
+  * Yellow/Warning: A password policy is enabled, but at least one content requirement is not enabled.
+
+  * Red/Error: No password policy is enabled.
+
+---
+
+### About the Architecture
+ Amazon EventBridge captures the Trusted Advisor Check Item Refresh Notification for IAM Password Policy. An AWS Lambda function is triggered via Amazon EventBridge to update the required fields flagged by Trusted Advisor or create a password policy if one doesn't exist.
+
+
+### Installation
+
+#### AWS SAM
+If you havent already, [install AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html). Ensure you are in the `IAMPasswordPolicy` folder then `build` and `deploy` your package
+
+```bash
+cd IAMPasswordPolicy
+sam build && sam deploy -g
+```
+
+#### Cloudformation - CLI
+```bash
+S3BUCKET=[REPLACE_WITH_YOUR_BUCKET]
+```
+
+Ensure you are in the `IAMPasswordPolicy` folder and use the `aws cloudformation package` utility
+
+```bash
+cd IAMPasswordPolicy
+
+aws cloudformation package --region us-east-1 --s3-bucket $S3BUCKET --template template.yaml --output-template-file template.output.yaml
+```
+Last, deploy the stack with the resulting yaml (`template.output.yaml`) through the CloudFormation Console or command line:
+
+```bash
+aws cloudformation deploy --region us-east-1 --template-file template.output.yaml --stack-name iam-password-policy --capabilities CAPABILITY_NAMED_IAM
+```
+
+
+More information about Trusted Advisor is available here: https://aws.amazon.com/premiumsupport/trustedadvisor/
+
+Please note that this is a just an example of how to setup automation with Trusted Advisor, Cloudwatch and Lambda. We recommend testing it and tailoring to your environment before using in your production envirnment.
+

--- a/IAMPasswordPolicy/samconfig.toml
+++ b/IAMPasswordPolicy/samconfig.toml
@@ -1,0 +1,34 @@
+# More information about the configuration file can be found here:
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-config.html
+version = 0.1
+
+[default]
+[default.global.parameters]
+stack_name = "iam-password-policy"
+
+[default.build.parameters]
+cached = true
+parallel = true
+
+[default.validate.parameters]
+lint = true
+
+[default.deploy.parameters]
+capabilities = "CAPABILITY_IAM"
+confirm_changeset = true
+resolve_s3 = true
+s3_prefix = "iam-password-policy"
+region = "us-east-1"
+image_repositories = []
+
+[default.package.parameters]
+resolve_s3 = true
+
+[default.sync.parameters]
+watch = true
+
+[default.local_start_api.parameters]
+warm_containers = "EAGER"
+
+[default.local_start_lambda.parameters]
+warm_containers = "EAGER"

--- a/IAMPasswordPolicy/set_password_policy/app.py
+++ b/IAMPasswordPolicy/set_password_policy/app.py
@@ -1,0 +1,38 @@
+import json
+import boto3
+
+
+def lambda_handler(event, context):
+    # Connect to IAM
+    iam = boto3.client("iam")
+
+    # Get status of Trusted Advisor Check from EventBridge
+    check_status = event["detail"]["status"]
+    current_policy = {}
+    if check_status == "WARN":
+        # Get details of current password policy
+        current_policy = iam.get_account_password_policy()["PasswordPolicy"]
+
+    # Set password policy for IAM
+    response = iam.update_account_password_policy(
+        MinimumPasswordLength=current_policy.get("MinimumPasswordLength", 12),
+        RequireSymbols=True,
+        RequireNumbers=True,
+        RequireUppercaseCharacters=True,
+        exRequireLowercaseCharacters=True,
+        AllowUsersToChangePassword=current_policy.get(
+            "AllowUsersToChangePassword", True
+        ),
+        PasswordReusePrevention=current_policy.get("PasswordReusePrevention", 24),
+        MaxPasswordAge=current_policy.get("MaxPasswordAge", 90),
+        HardExpiry=current_policy.get("HardExpiry", False),
+    )
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(
+            {
+                "response": response,
+            }
+        ),
+    }

--- a/IAMPasswordPolicy/set_password_policy/app.py
+++ b/IAMPasswordPolicy/set_password_policy/app.py
@@ -19,11 +19,11 @@ def lambda_handler(event, context):
         RequireSymbols=True,
         RequireNumbers=True,
         RequireUppercaseCharacters=True,
-        exRequireLowercaseCharacters=True,
+        RequireLowercaseCharacters=True,
         AllowUsersToChangePassword=current_policy.get(
             "AllowUsersToChangePassword", True
         ),
-        PasswordReusePrevention=current_policy.get("PasswordReusePrevention", 24),
+        PasswordReusePrevention=current_policy.get("PasswordReusePrevention", 12),
         MaxPasswordAge=current_policy.get("MaxPasswordAge", 90),
         HardExpiry=current_policy.get("HardExpiry", False),
     )

--- a/IAMPasswordPolicy/template.yaml
+++ b/IAMPasswordPolicy/template.yaml
@@ -1,0 +1,43 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 3
+    MemorySize: 128
+    Runtime: python3.11
+    Architectures:
+        - arm64
+
+Resources:
+  SetPasswordPolicyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: set_password_policy/
+      Handler: app.lambda_handler
+      Policies:
+        - AWSLambdaExecute
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+              - "iam:UpdateAccountPasswordPolicy"
+              - "iam:GetAccountPasswordPolicy"
+              Resource: "*"
+      Events:
+        CloudWatchEvent:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              source: 
+                - "aws.trustedadvisor"
+              detail-type: 
+                - "Trusted Advisor Check Item Refresh Notification"
+              detail: 
+                status: 
+                  - "WARN"
+                  - "ERROR"
+                check-name:
+                  - "IAM Password Policy"
+            State: "ENABLED"
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added auto-remediation for IAM Password Policy.
- Remediation enforces the following values:
    - Require Symbols
    - Require Numbers
    - Require Uppercase Characters
    - Require Lowercase Characters

- If an account doesn't have a password policy, Trusted Advisor shows this as an Red/Error state. Enforce the values above as well as: 
    - Sets minimum password length to 12
    - Allows users to change password  
    - Sets PasswordResusePrevention to 12
    - Sets the max password age to 90 days
    - Sets Hard Expiry to false

- If a password policy exists, keep the existing values and enforce the requirements outlined in the first point.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.